### PR TITLE
Remove Studio Mirai copyright, and add acknowledgement section to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Creates can use [Flow](https://github.com/VisionDeCreator/flow "Flow") to handle
 ## How it works
 ![Water Cooler life cycle](https://github.com/VisionDeCreator/water_cooler/blob/main/images/water_cooler.png?raw=true)
 
-
 ## Contribute
 If you are interested in contributing to the project please see the [Move Style Guide](https://chip-brownie-44a.notion.site/Move-Style-Guide-3d8bd29c18794874ae791754fa4a84fa "Move Style Guide") to keep the code readable.
+
+## Acknowledgements
+- This project was inspired by Studio Mirai's ["Prime Machin" smart contracts](https://github.com/mirai-labs/prime-machin-contracts).

--- a/contracts/sources/attributes.move
+++ b/contracts/sources/attributes.move
@@ -1,8 +1,3 @@
-/*
- * Copyright (c) 2024 Studio Mirai, Ltd.
- * SPDX-License-Identifier: MIT
- */
-
 module galliun::attributes {
     // === Imports ===
 

--- a/contracts/sources/collection.move
+++ b/contracts/sources/collection.move
@@ -1,12 +1,3 @@
-/*
- * Copyright (c) 2024 Studio Mirai, Ltd.
- * SPDX-License-Identifier: MIT
- */
-
-// This object holds the supply of NFTs in a collection
-// It was created for the purpose of avoiding a cercular dependency 
-// between the Registry and the WaterCooler which need to share the 
-// supply of NFTs in the collection
 module galliun::collection {
 
     // === Structs ===

--- a/contracts/sources/registry.move
+++ b/contracts/sources/registry.move
@@ -1,8 +1,3 @@
-/*
- * Copyright (c) 2024 Studio Mirai, Ltd.
- * SPDX-License-Identifier: MIT
- */
-
 module galliun::registry {
 
     // === Imports ===


### PR DESCRIPTION
This commit removes Studio Mirai copyright from the package. The reason for this is Galliun was inspired by Studio Mirai, but not written by us. There are several changes to the code, especially in registry.move, that do not reflect our work.